### PR TITLE
Sea level 2a

### DIFF
--- a/include/aspect/boundary_traction/GIA_traction.h
+++ b/include/aspect/boundary_traction/GIA_traction.h
@@ -1,0 +1,106 @@
+/*
+  Copyright (C) 2011 - 2019 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef _aspect_boundary_traction_function_h
+#define _aspect_boundary_traction_function_h
+
+#include <aspect/boundary_traction/interface.h>
+#include <aspect/simulator_access.h>
+#include <aspect/utilities.h>
+
+#include <deal.II/base/parsed_function.h>
+
+namespace aspect
+{
+  namespace BoundaryTraction
+  {
+    using namespace dealii;
+
+    /**
+     * A class that implements traction boundary conditions based on a
+     * functional description provided in the input file.
+     *
+     * @ingroup BoundaryTractions
+     */
+    template <int dim>
+    class GIAtraction : public Interface<dim>, public SimulatorAccess<dim>
+    {
+      public:
+        /**
+         * Constructor.
+         */
+        traction ();
+
+        /**
+         * Return the boundary traction as a function of position. The
+         * (outward) normal vector to the domain is also provided as
+         * a second argument.
+         */
+        Tensor<1,dim>
+        boundary_traction (const types::boundary_id boundary_indicator,
+                           const Point<dim> &position,
+                           const Tensor<1,dim> &normal_vector) const override;
+
+        /**
+         * A function that is called at the beginning of each time step to
+         * indicate what the model time is for which the boundary values will
+         * next be evaluated. For the current class, the function passes to
+         * the parsed function what the current time is.
+         */
+        void
+        update () override;
+
+        /**
+         * Declare the parameters this class takes through input files. The
+         * default implementation of this function does not describe any
+         * parameters. Consequently, derived classes do not have to overload
+         * this function if they do not take any runtime parameters.
+         */
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter file.
+         * The default implementation of this function does not read any
+         * parameters. Consequently, derived classes do not have to overload
+         * this function if they do not take any runtime parameters.
+         */
+        void
+        parse_parameters (ParameterHandler &prm) override;
+
+      private:
+        /**
+         * A function object representing the components of the traction.
+         */
+        Functions::ParsedFunction<dim> boundary_traction_function;
+
+        /**
+         * The coordinate representation to evaluate the function. Possible
+         * choices are depth, cartesian and spherical.
+         */
+        Utilities::Coordinates::CoordinateSystem coordinate_system;
+    };
+  }
+}
+
+
+#endif

--- a/include/aspect/boundary_traction/GIA_traction.h
+++ b/include/aspect/boundary_traction/GIA_traction.h
@@ -19,14 +19,14 @@
 */
 
 
-#ifndef _aspect_boundary_traction_function_h
-#define _aspect_boundary_traction_function_h
+#ifndef _aspect_boundary_traction_GIAtraction_h
+#define _aspect_boundary_traction_GIAtraction_h
 
 #include <aspect/boundary_traction/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/utilities.h>
 
-#include <deal.II/base/parsed_function.h>
+// #include <deal.II/base/parsed_function.h>
 
 namespace aspect
 {
@@ -47,7 +47,7 @@ namespace aspect
         /**
          * Constructor.
          */
-        traction ();
+        GIAtraction ();
 
         /**
          * Return the boundary traction as a function of position. The
@@ -91,13 +91,13 @@ namespace aspect
         /**
          * A function object representing the components of the traction.
          */
-        Functions::ParsedFunction<dim> boundary_traction_function;
+        // Functions::ParsedFunction<dim> boundary_traction_function;
 
         /**
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
          */
-        Utilities::Coordinates::CoordinateSystem coordinate_system;
+        // Utilities::Coordinates::CoordinateSystem coordinate_system;
     };
   }
 }

--- a/include/aspect/postprocess/sealevel.h
+++ b/include/aspect/postprocess/sealevel.h
@@ -33,6 +33,12 @@ namespace aspect
     {
       public:
         /**
+         * Function to determine sea level for any given location
+         */
+        double
+        sea_level_equation(const Point<dim> &position);
+
+        /**
          * Output sea level [m] to file
          */
         std::pair<std::string,std::string> execute (TableHandler &statistics) override;
@@ -74,12 +80,6 @@ namespace aspect
          */
 
       private:
-        /**
-         * Function to determine sea level for any given location
-         */
-        double
-        sea_level_equation(const Point<dim> &position);
-
         /**
          * Whether or not to produce text files with sea level values
          */

--- a/source/boundary_traction/GIA_traction.cc
+++ b/source/boundary_traction/GIA_traction.cc
@@ -21,6 +21,7 @@
 
 #include <aspect/boundary_traction/GIA_traction.h>
 #include <aspect/global.h>
+#include <aspect/postprocess/sealevel.h>
 
 namespace aspect
 {
@@ -28,93 +29,59 @@ namespace aspect
   {
     template <int dim>
     GIAtraction<dim>::GIAtraction ()
+    // void
+    // GIAtraction<dim>::initialize()
     {}
+
+
 
     template <int dim>
     Tensor<1,dim>
-    Function<dim>::
+    GIAtraction<dim>::
     boundary_traction (const types::boundary_id,
                        const Point<dim> &position,
-                       const Tensor<1,dim> &) const
+                       const Tensor<1,dim> &normal_vector) const
     {
-      // Tensor<1,dim> traction;
-      // Utilities::NaturalCoordinate<dim> point =
-      //   this->get_geometry_model().cartesian_to_other_coordinates(position, coordinate_system);
-      // for (unsigned int d=0; d<dim; ++d)
-      //   traction[d] = boundary_traction_function.value(Utilities::convert_array_to_point<dim>(point.get_coordinates()),d);
-
-      // return traction;
+      // const double surface_load = SeaLevel<dim>::sea_level_equation(position);
+      Postprocess::SeaLevel<dim> sealevel;
+      const double surface_load = sealevel.sea_level_equation(position);
+      return -surface_load * normal_vector;
     }
 
-    // template <int dim>
-    // void
-    // GIAtraction<dim>::initialize ()
-    // {
-    //   for (const auto &bv : this->get_boundary_traction())
-    //     if (bv.second.get() == this)
-    //       boundary_ids.insert(bv.first);
-
-    //   AssertThrow(*(boundary_ids.begin()) != numbers::invalid_boundary_id,
-    //               ExcMessage("Did not find the boundary indicator for the traction ascii data plugin."));
-
-    //   Utilities::AsciiDataBoundary<dim>::initialize(boundary_ids,
-    //                                                 1);
-    // }
-
-    // MAYBE USE THIS FOR ACCESSING GEOID POSTPROCESSOR?
-    // template <>
-    // std::pair<std::pair<double, std::pair<std::vector<double>,std::vector<double> > >, std::pair<double, std::pair<std::vector<double>,std::vector<double> > > >
-    // Geoid<3>::dynamic_topography_contribution(const double &outer_radius,
-    //                                           const double &inner_radius) const
-    // {
-    //   // Get a pointer to the dynamic topography postprocessor.
-    //   const Postprocess::DynamicTopography<3> &dynamic_topography =
-    //     this->get_postprocess_manager().template get_matching_postprocessor<Postprocess::DynamicTopography<3> >();
-    // }
-
-    // template <int dim>
-    // Tensor<1,dim>
-    // AsciiData<dim>::
-    // boundary_traction (const types::boundary_id boundary_indicator,
-    //                    const Point<dim> &position,
-    //                    const Tensor<1,dim> &normal_vector) const
-    // {
-    //   const double pressure = Utilities::AsciiDataBoundary<dim>::get_data_component(boundary_indicator,
-    //                                                                                 position,
-    //                                                                                 0);
-    //   return -pressure * normal_vector;;
-    // }
 
 
-    // template <int dim>
-    // void
-    // AsciiData<dim>::update()
-    // {
-    //   Interface<dim>::update ();
-    //   Utilities::AsciiDataBoundary<dim>::update();
-    // }
+    template <int dim>
+    void
+    GIAtraction<dim>::update()
+    {
+      Interface<dim>::update ();
+    }
+  
 
 
- template <int dim>
+    template <int dim>
     void
     GIAtraction<dim>::declare_parameters (ParameterHandler &prm)
     {
       prm.enter_subsection("Boundary traction model");
       {
-        prm.enter_subsection("GIAtraction");
+        prm.enter_subsection("GIA traction");
         {
-          prm.declare_entry ("Coordinate system", "cartesian",
-                             Patterns::Selection ("cartesian|spherical|depth"),
-                             "A selection that determines the assumed coordinate "
-                             "system for the function variables. Allowed values "
-                             "are `cartesian', `spherical', and `depth'. `spherical' coordinates "
-                             "are interpreted as r,phi or r,phi,theta in 2D/3D "
-                             "respectively with theta being the polar angle. `depth' "
-                             "will create a function, in which only the first "
-                             "parameter is non-zero, which is interpreted to "
-                             "be the depth of the point.");
+          // prm.declare_entry ("Coordinate system", "cartesian",
+          //                    Patterns::Selection ("cartesian|spherical|depth"),
+          //                    "A selection that determines the assumed coordinate "
+          //                    "system for the function variables. Allowed values "
+          //                    "are `cartesian', `spherical', and `depth'. `spherical' coordinates "
+          //                    "are interpreted as r,phi or r,phi,theta in 2D/3D "
+          //                    "respectively with theta being the polar angle. `depth' "
+          //                    "will create a function, in which only the first "
+          //                    "parameter is non-zero, which is interpreted to "
+          //                    "be the depth of the point.");
 
-          Functions::ParsedFunction<dim>::declare_parameters (prm, dim);
+          // GIAtraction::ParsedFunction<dim>::declare_parameters (prm, dim);
+          // Utilities::AsciiDataBoundary<dim>::declare_parameters(prm,
+                                                              // "$ASPECT_SOURCE_DIR/data/boundary-traction/ascii-data/test/",
+                                                              // "box_2d_%s.%d.txt");
         }
         prm.leave_subsection();
       }
@@ -130,7 +97,7 @@ namespace aspect
       {
         prm.enter_subsection("GIAtraction");
         {
-          coordinate_system = Utilities::Coordinates::string_to_coordinate_system(prm.get("Coordinate system"));
+          // coordinate_system = Utilities::Coordinates::string_to_coordinate_system(prm.get("Coordinate system"));
         }
         // try
         //   {
@@ -160,36 +127,17 @@ namespace aspect
   namespace BoundaryTraction
   {
     ASPECT_REGISTER_BOUNDARY_TRACTION_MODEL(GIAtraction,
-                                            "ascii data",
+                                            "GIA traction",
                                             "Implementation of a model in which the boundary "
-                                            "traction is derived from files containing pressure data "
-                                            "in ascii format. The pressure given in the data file is "
-                                            "applied as traction normal to the surface of a given boundary, "
-                                            "pointing inwards. Note the required format of the "
-                                            "input data: The first lines may contain any number of comments "
-                                            "if they begin with `#', but one of these lines needs to "
-                                            "contain the number of grid points in each dimension as "
-                                            "for example `# POINTS: 3 3'. "
-                                            "The order of the data columns "
-                                            "has to be `x', `Pressure [Pa]' in a 2d model and "
-                                            " `x', `y', `Pressure [Pa]' in a 3d model, which means that "
-                                            "there has to be a single column "
-                                            "containing the pressure. "
-                                            "Note that the data in the input "
-                                            "files need to be sorted in a specific order: "
-                                            "the first coordinate needs to ascend first, "
-                                            "followed by the second in order to "
-                                            "assign the correct data to the prescribed coordinates. "
-                                            "If you use a spherical model, "
-                                            "then the data will still be handled as Cartesian, "
-                                            "however the assumed grid changes. `x' will be replaced by "
-                                            "the radial distance of the point to the bottom of the model, "
-                                            "`y' by the azimuth angle and `z' by the polar angle measured "
-                                            "positive from the north pole. The grid will be assumed to be "
-                                            "a latitude-longitude grid. Note that the order "
-                                            "of spherical coordinates is `r', `phi', `theta' "
-                                            "and not `r', `theta', `phi', since this allows "
-                                            "for dimension independent expressions.")
+                                            "traction is given in terms of an explicit formula "
+                                            "that is elaborated in the parameters in section "
+                                            "``Boundary traction model|Function''. "
+                                            "\n\n"
+                                            "The formula you describe in the mentioned "
+                                            "section is a semicolon separated list of traction components "
+                                            "for each of the $d$ components of the traction vector. "
+                                            "These $d$ formulas are interpreted as having units "
+                                            "Pa.")
   }
 }
 

--- a/source/boundary_traction/GIA_traction.cc
+++ b/source/boundary_traction/GIA_traction.cc
@@ -1,0 +1,195 @@
+/*
+  Copyright (C) 2011 - 2019 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <aspect/boundary_traction/GIA_traction.h>
+#include <aspect/global.h>
+
+namespace aspect
+{
+  namespace BoundaryTraction
+  {
+    template <int dim>
+    GIAtraction<dim>::GIAtraction ()
+    {}
+
+    template <int dim>
+    Tensor<1,dim>
+    Function<dim>::
+    boundary_traction (const types::boundary_id,
+                       const Point<dim> &position,
+                       const Tensor<1,dim> &) const
+    {
+      // Tensor<1,dim> traction;
+      // Utilities::NaturalCoordinate<dim> point =
+      //   this->get_geometry_model().cartesian_to_other_coordinates(position, coordinate_system);
+      // for (unsigned int d=0; d<dim; ++d)
+      //   traction[d] = boundary_traction_function.value(Utilities::convert_array_to_point<dim>(point.get_coordinates()),d);
+
+      // return traction;
+    }
+
+    // template <int dim>
+    // void
+    // GIAtraction<dim>::initialize ()
+    // {
+    //   for (const auto &bv : this->get_boundary_traction())
+    //     if (bv.second.get() == this)
+    //       boundary_ids.insert(bv.first);
+
+    //   AssertThrow(*(boundary_ids.begin()) != numbers::invalid_boundary_id,
+    //               ExcMessage("Did not find the boundary indicator for the traction ascii data plugin."));
+
+    //   Utilities::AsciiDataBoundary<dim>::initialize(boundary_ids,
+    //                                                 1);
+    // }
+
+    // MAYBE USE THIS FOR ACCESSING GEOID POSTPROCESSOR?
+    // template <>
+    // std::pair<std::pair<double, std::pair<std::vector<double>,std::vector<double> > >, std::pair<double, std::pair<std::vector<double>,std::vector<double> > > >
+    // Geoid<3>::dynamic_topography_contribution(const double &outer_radius,
+    //                                           const double &inner_radius) const
+    // {
+    //   // Get a pointer to the dynamic topography postprocessor.
+    //   const Postprocess::DynamicTopography<3> &dynamic_topography =
+    //     this->get_postprocess_manager().template get_matching_postprocessor<Postprocess::DynamicTopography<3> >();
+    // }
+
+    // template <int dim>
+    // Tensor<1,dim>
+    // AsciiData<dim>::
+    // boundary_traction (const types::boundary_id boundary_indicator,
+    //                    const Point<dim> &position,
+    //                    const Tensor<1,dim> &normal_vector) const
+    // {
+    //   const double pressure = Utilities::AsciiDataBoundary<dim>::get_data_component(boundary_indicator,
+    //                                                                                 position,
+    //                                                                                 0);
+    //   return -pressure * normal_vector;;
+    // }
+
+
+    // template <int dim>
+    // void
+    // AsciiData<dim>::update()
+    // {
+    //   Interface<dim>::update ();
+    //   Utilities::AsciiDataBoundary<dim>::update();
+    // }
+
+
+ template <int dim>
+    void
+    GIAtraction<dim>::declare_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Boundary traction model");
+      {
+        prm.enter_subsection("GIAtraction");
+        {
+          prm.declare_entry ("Coordinate system", "cartesian",
+                             Patterns::Selection ("cartesian|spherical|depth"),
+                             "A selection that determines the assumed coordinate "
+                             "system for the function variables. Allowed values "
+                             "are `cartesian', `spherical', and `depth'. `spherical' coordinates "
+                             "are interpreted as r,phi or r,phi,theta in 2D/3D "
+                             "respectively with theta being the polar angle. `depth' "
+                             "will create a function, in which only the first "
+                             "parameter is non-zero, which is interpreted to "
+                             "be the depth of the point.");
+
+          Functions::ParsedFunction<dim>::declare_parameters (prm, dim);
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+
+    template <int dim>
+    void
+    GIAtraction<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Boundary traction model");
+      {
+        prm.enter_subsection("GIAtraction");
+        {
+          coordinate_system = Utilities::Coordinates::string_to_coordinate_system(prm.get("Coordinate system"));
+        }
+        // try
+        //   {
+        //     boundary_traction_function.parse_parameters (prm);
+        //   }
+        // catch (...)
+        //   {
+        //     std::cerr << "ERROR: FunctionParser failed to parse\n"
+        //               << "\t'Boundary traction model.Function'\n"
+        //               << "with expression\n"
+        //               << "\t'" << prm.get("Function expression") << "'"
+        //               << "More information about the cause of the parse error \n"
+        //               << "is shown below.\n";
+        //     throw;
+        //   }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace BoundaryTraction
+  {
+    ASPECT_REGISTER_BOUNDARY_TRACTION_MODEL(GIAtraction,
+                                            "ascii data",
+                                            "Implementation of a model in which the boundary "
+                                            "traction is derived from files containing pressure data "
+                                            "in ascii format. The pressure given in the data file is "
+                                            "applied as traction normal to the surface of a given boundary, "
+                                            "pointing inwards. Note the required format of the "
+                                            "input data: The first lines may contain any number of comments "
+                                            "if they begin with `#', but one of these lines needs to "
+                                            "contain the number of grid points in each dimension as "
+                                            "for example `# POINTS: 3 3'. "
+                                            "The order of the data columns "
+                                            "has to be `x', `Pressure [Pa]' in a 2d model and "
+                                            " `x', `y', `Pressure [Pa]' in a 3d model, which means that "
+                                            "there has to be a single column "
+                                            "containing the pressure. "
+                                            "Note that the data in the input "
+                                            "files need to be sorted in a specific order: "
+                                            "the first coordinate needs to ascend first, "
+                                            "followed by the second in order to "
+                                            "assign the correct data to the prescribed coordinates. "
+                                            "If you use a spherical model, "
+                                            "then the data will still be handled as Cartesian, "
+                                            "however the assumed grid changes. `x' will be replaced by "
+                                            "the radial distance of the point to the bottom of the model, "
+                                            "`y' by the azimuth angle and `z' by the polar angle measured "
+                                            "positive from the north pole. The grid will be assumed to be "
+                                            "a latitude-longitude grid. Note that the order "
+                                            "of spherical coordinates is `r', `phi', `theta' "
+                                            "and not `r', `theta', `phi', since this allows "
+                                            "for dimension independent expressions.")
+  }
+}
+


### PR DESCRIPTION
boundary traction plugin implemented for sea level post processor.  It compiles, but I have not been able to get it to run (I think I'm just not using the right format for boundary traction in the .prm for a 3d spherical shell.  I could not find any examples for this geometry.  